### PR TITLE
fix: count genesis block in height calculation

### DIFF
--- a/src/db/blocks.py
+++ b/src/db/blocks.py
@@ -120,15 +120,18 @@ class BlockRepository:
                     else:
                         # Parent not found anywhere
                         if block.slot == 0 or block.hash == chain_root_hash:
-                            # Genesis block or chain root - no parent requirement
-                            block.height = 0
+                            # Genesis block or chain root - no parent requirement.
+                            # Height starts at 1 to count the genesis block itself,
+                            # so chain height = total number of blocks.
+                            # See: https://github.com/logos-blockchain/logos-blockchain-block-explorer-template/issues/12
+                            block.height = 1
                             parent_heights[block.hash] = block.height
                             resolved.add(block.hash)
                             made_progress = True
                             if block.hash == chain_root_hash:
                                 logger.info(
                                     f"Chain root block: hash={block.hash.hex()[:16]}..., "
-                                    f"slot={block.slot}, height=0"
+                                    f"slot={block.slot}, height=1"
                                 )
                         else:
                             # Orphan block - parent doesn't exist

--- a/src/node/api/fake.py
+++ b/src/node/api/fake.py
@@ -28,7 +28,7 @@ class FakeNodeApi(NodeApi):
             lib="0" * 64,
             tip="0" * 64,
             slot=self.current_slot,
-            height=0,
+            height=1,  # Genesis block counts as height 1
             mode="Fake",
         )
 


### PR DESCRIPTION
## Summary

Fixes #12.

Genesis block was assigned `height=0`, causing chain height to undercount by one. The height of the chain tip should equal the total number of blocks.

## Changes

- `src/db/blocks.py`: Genesis block now starts at `height=1`
- `src/node/api/fake.py`: Fake node genesis height updated to `1`

## Before/After

| Blocks | Before | After |
|--------|--------|-------|
| Genesis only | height=0 | height=1 |
| Genesis + 99 | height=99 | height=100 |

## Note

Tests require Python 3.14 which is not available in the current environment. Please verify with your local test suite.

Fixes #12